### PR TITLE
住所登録の修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,7 +39,7 @@ end
   end
 
   def address_params
-    params.require(:address).permit(:family_name, :name, :family_name_furigana, :name_furigana, :potalcode, :address, :prefectures,  :municipalities)
+    params.require(:address).permit(:family_name, :name, :family_name_furigana, :name_furigana, :potalcode, :address, :prefectures,  :municipalities, :building_name, :tel )
   end
   
 end

--- a/app/views/devise/registrations/create_address.haml
+++ b/app/views/devise/registrations/create_address.haml
@@ -4,6 +4,8 @@
       = link_to root_path do
         = image_tag("logo.png")
   .account-page__inner.clearfix
-    %h2 登録が完了しました
-    = link_to "トップページへ"
+    .account-page__inner--left.account-page__header
+      %h2 登録が完了しました
+    .action
+      = link_to "トップページへ", root_path
             

--- a/app/views/devise/registrations/new_address.haml
+++ b/app/views/devise/registrations/new_address.haml
@@ -30,7 +30,7 @@
             = f.label :potalcode, "郵便番号"
             %span 必須
           .field-input
-            = f.text_field :potalcode, placeholder: 
+            = f.text_field :potalcode
         
         .field
           .field-label


### PR DESCRIPTION
＃what
住所登録画面が表示されないため、表示されるように実装
電話番号・建物名の登録許可を可能

＃why
placeholderの後に記述していないためのエラーが起きた
permitで許可していなかったため登録されていなかった。
